### PR TITLE
Omit urban results from downloaded reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Mustache tags are supported so we can return a warning message if a
 deployment has fewer than 150 responses. See
 `reporter.tests.TestRendering.test_warning`.
 
+# Variables passed to Rmd templates
+
+* `rendering__name`: `Rendering.name`, i.e. the user's name for the project
+* `form__name`: `Form.name`, e.g. `Tajikistan (DHS 2012)`
+* `request__show_urban`: the value of `?show_urban=` in the URL used to request
+  the report
+
+
 # Development _without_ Dokku
 
 This application requires a working instance of KoBoToolbox to run. See

--- a/demo/src/components/Report.js
+++ b/demo/src/components/Report.js
@@ -62,8 +62,18 @@ var Report = React.createClass({
             }
             {this.state.renderingHtml !== 'loading' &&
               <div className="project-links">
-                <ProjectLink className="bordered-navlink" href={'/rendering/' + this.props.params.id + '.pdf'}>download PDF</ProjectLink>
-                <ProjectLink className="bordered-navlink" href={'/rendering/' + this.props.params.id + '.docx'}>download DOC</ProjectLink>
+                <ProjectLink
+                  className="bordered-navlink"
+                  href={'/rendering/' + this.props.params.id + '.pdf?show_urban=' + this.state.urbanVisible}
+                >
+                  download PDF
+                </ProjectLink>
+                <ProjectLink
+                  className="bordered-navlink"
+                  href={'/rendering/' + this.props.params.id + '.docx?show_urban=' + this.state.urbanVisible}
+                >
+                  download DOC
+                </ProjectLink>
               </div>
             }
             <div className="project-footer">

--- a/reporter/models.py
+++ b/reporter/models.py
@@ -158,7 +158,7 @@ class Rendering(models.Model):
             f.write(value)
         return filename
 
-    def render(self, extension):
+    def render(self, extension, request=None):
         self._log_message('render begin  ')
         folder = tempfile.mkdtemp()
         try:
@@ -178,6 +178,14 @@ class Rendering(models.Model):
                 folder=folder,
                 name='form__name',
                 value=self.form_name
+            )
+            request__show_urban_filename = self._write_variable_to_file(
+                folder=folder,
+                name='request__show_urban',
+                value=(
+                    request.GET.get('show_urban', 'true') if request
+                        else 'true'
+                )
             )
 
             with open(path, 'w') as f:
@@ -199,6 +207,7 @@ class Rendering(models.Model):
                 'extension': extension,
                 'rendering__name_filename': rendering__name_filename,
                 'form__name_filename': form__name_filename,
+                'request__show_urban_filename': request__show_urban_filename,
             }
             script = render_to_string('compile.R', context)
             path = os.path.join(folder, 'temp.R')

--- a/reporter/rmd_templates/wealth.Rmd
+++ b/reporter/rmd_templates/wealth.Rmd
@@ -45,6 +45,10 @@ if ("UrbanM4M" %in% names(respondents)) {
   show_urban <- TRUE
 }
 
+if (!as.logical(request__show_urban)) {
+  show_urban <- FALSE
+}
+
 
 cutoff <- 100
 n <- nrow(respondents)

--- a/reporter/templates/compile.R
+++ b/reporter/templates/compile.R
@@ -7,6 +7,7 @@ opts_chunk$set(error=FALSE, warning=FALSE)
 compile <- function() {
     rendering__name <- readLines('{{ rendering__name_filename }}')
     form__name <- readLines('{{ form__name_filename }}')
+    request__show_urban <- readLines('{{ request__show_urban_filename }}')
 
     {% if url %}
     ## 0. download the data

--- a/reporter/views.py
+++ b/reporter/views.py
@@ -48,7 +48,7 @@ def rendering(request, id, extension):
     r = Rendering.objects.get(id=id)
     if request.user != r.user:
         return render(request, 'not_owner.html')
-    result = r.render(extension)
+    result = r.render(extension, request)
     response = HttpResponse(result)
     if extension != 'html':
         filename = '%(id)s.%(extension)s' % locals()


### PR DESCRIPTION
when they are hidden in the browser. Fixes #127