### PR TITLE
Replace react-zeroclipboard with native API

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,6 @@
     "react-router": "0.13.x",
     "react-select": "^0.6.11",
     "react-tooltip": "^0.6.4",
-    "react-zeroclipboard": "^1.1.0",
     "react-modal": "0.5.0",
     "reflux": "^0.2.7"
   },

--- a/demo/src/components/ProjectList.js
+++ b/demo/src/components/ProjectList.js
@@ -9,7 +9,6 @@ import moment from 'moment';
 import {requireLoggedInMixin} from '../mixins/requireLogins';
 import actions from '../actions/actions';
 import {renderingsStore} from '../stores/renderings';
-import ReactZeroClipboard from 'react-zeroclipboard';
 import Modal from 'react-modal';
 
 require('styles/ProjectList.scss');
@@ -48,6 +47,12 @@ var ProjectList = React.createClass({
   componentDidMount () {
     this.listenTo(renderingsStore, this.renderingsStoreChanged);
     actions.listRenderings();
+  },
+  copyText (evt) {
+    var $ect = evt.currentTarget;
+    navigator.clipboard.writeText($ect.dataset.textToCopy).then(
+      this.afterCopy
+    );
   },
   syncProject (evt) {
     var $ect = evt.currentTarget;
@@ -151,9 +156,13 @@ var ProjectList = React.createClass({
                           <ProjectAttributeLink m='enter-data' href={enter_data_link} target='_blank'>
                             enter data
                           </ProjectAttributeLink>
-                          <ReactZeroClipboard text={enter_data_link} onAfterCopy={this.afterCopy}>
-                            <button className="button-copy">copy link</button>
-                          </ReactZeroClipboard>
+                          <button
+                            className="button-copy"
+                            onClick={this.copyText}
+                            data-text-to-copy={enter_data_link}
+                          >
+                            copy link
+                          </button>
                         </ProjectAttribute>
                         <ProjectAttribute m='submissions'>
                           <label>{submission_count} submissions</label>

--- a/demo/src/styles/ProjectList.scss
+++ b/demo/src/styles/ProjectList.scss
@@ -98,7 +98,7 @@
     display: inline-block;
     cursor: pointer;
 
-    &:hover, &.zeroclipboard-is-hover {
+    &:hover {
       color: #2990C2;
       border-color: #2990C2;
     }


### PR DESCRIPTION
Fixes #87. ZeroClipboard is an obsolete, Flash-based library. The native `navigator.clipboard` approach is supported by major browsers: https://caniuse.com/mdn-api_clipboard_writetext.