### PR TITLE
Replace `/how-to-use-the-equity-tool/` with…

### DIFF
--- a/demo/src/components/GettingStarted.js
+++ b/demo/src/components/GettingStarted.js
@@ -57,7 +57,7 @@ var GettingStarted = React.createClass({
               <ContentWrap>
                 <ContentTitle>EquityTool Surveys</ContentTitle>
                 <p>Create a new survey or a view a list of your current surveys.</p>
-                <p>For more information about how to use the tool, click <a href="https://www.equitytool.org/how-to-use-the-equity-tool/">here</a>.</p>
+                <p>For more information about how to use the tool, click <a href="https://www.equitytool.org/data-collection-options/">here</a>.</p>
                 <div>
                   <p>
                     <BorderedNavlink m='new-project' to='new-project'>
@@ -74,7 +74,7 @@ var GettingStarted = React.createClass({
             <ContentWrap>
               <ContentTitle>Getting Started with the EquityTool</ContentTitle>
               <p>Create a free account to begin measuring the wealth distribution of your program beneficiaries. After registration, you will immediately be able to log in to the EquityTool to set up a survey, and begin collecting data.</p>
-              <p>For more information about how to use the tool, click <a href="https://www.equitytool.org/how-to-use-the-equity-tool/">here</a>.</p>
+              <p>For more information about how to use the tool, click <a href="https://www.equitytool.org/data-collection-options/">here</a>.</p>
               <div className='getting-started__buttons'>
                 <BorderedNavlink href={authUrls.register} m='register'>
                   Create account

--- a/demo/src/components/ProjectList.js
+++ b/demo/src/components/ProjectList.js
@@ -111,7 +111,7 @@ var ProjectList = React.createClass({
             <ContentTitle>My Surveys</ContentTitle>
             <p>This page contains a list of your survey projects. Each survey is assigned a unique URL that can be used by multiple data collectors at the same time. Simply copy the link and send it to your data collectors. Remember, surveys can be conducted online or offline. Before viewing a report, be sure to click "sync" to update all data collected and to see the most up-to-date results. </p>
             <p>Each survey shows the number of submissions, or surveys with complete data uploaded to the project. Click on the "sync" button to update data collected across all survey enumerators. Under "View report" select how you would like to view your survey results: in your browser, as a PDF or as a Word document.</p>
-            <p>For more information about how to use the tool, click <a href="https://www.equitytool.org/how-to-use-the-equity-tool/">here</a>.</p>
+            <p>For more information about how to use the tool, click <a href="https://www.equitytool.org/data-collection-options/">here</a>.</p>
             <div className="new-project-wrapper" >
               <BorderedNavlink m='new-project' to='new-project'>
                 New survey


### PR DESCRIPTION
`/data-collection-options/` in links to instructions