### PR TITLE
Use Reflux.js from quasi-maintained repository

### DIFF
--- a/jsapp/package-lock.json
+++ b/jsapp/package-lock.json
@@ -17,7 +17,7 @@
         "react-router": "^5.2.0",
         "react-select": "^4.3.0",
         "react-tooltip": "^4.2.18",
-        "reflux": "^6.4.1",
+        "reflux-react-16": "github:ied3vil/reflux-react-16#d5f04cf7f5ea44ba26c134039127527104f2f533",
         "webpack-cli": "^4.6.0"
       },
       "devDependencies": {
@@ -8445,21 +8445,24 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/reflux": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/reflux/-/reflux-6.4.1.tgz",
-      "integrity": "sha1-i7urr/VM8bgiM9Z90lQv2tKo1ng=",
-      "dependencies": {
-        "eventemitter3": "^1.1.1",
-        "reflux-core": "^1.0.0"
-      }
-    },
     "node_modules/reflux-core": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reflux-core/-/reflux-core-1.0.0.tgz",
       "integrity": "sha1-65uq4tUIcTJK25MSWDwS4HDNYdM=",
       "dependencies": {
         "eventemitter3": "^1.1.1"
+      }
+    },
+    "node_modules/reflux-react-16": {
+      "version": "1.0.2",
+      "resolved": "git+ssh://git@github.com/ied3vil/reflux-react-16.git#d5f04cf7f5ea44ba26c134039127527104f2f533",
+      "integrity": "sha512-Kk341+qoFKUYjwy2+HGO8tQxu/DO14QXtj24nPdeEvexZ6NfWgtk49Jgscd2UOCX4zKZozuL66h75G8s1vO2mA==",
+      "license": "ISC",
+      "dependencies": {
+        "reflux-core": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.2.0 || ^17.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -18873,21 +18876,20 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "reflux": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/reflux/-/reflux-6.4.1.tgz",
-      "integrity": "sha1-i7urr/VM8bgiM9Z90lQv2tKo1ng=",
-      "requires": {
-        "eventemitter3": "^1.1.1",
-        "reflux-core": "^1.0.0"
-      }
-    },
     "reflux-core": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reflux-core/-/reflux-core-1.0.0.tgz",
       "integrity": "sha1-65uq4tUIcTJK25MSWDwS4HDNYdM=",
       "requires": {
         "eventemitter3": "^1.1.1"
+      }
+    },
+    "reflux-react-16": {
+      "version": "git+ssh://git@github.com/ied3vil/reflux-react-16.git#d5f04cf7f5ea44ba26c134039127527104f2f533",
+      "integrity": "sha512-Kk341+qoFKUYjwy2+HGO8tQxu/DO14QXtj24nPdeEvexZ6NfWgtk49Jgscd2UOCX4zKZozuL66h75G8s1vO2mA==",
+      "from": "reflux-react-16@github:ied3vil/reflux-react-16#d5f04cf7f5ea44ba26c134039127527104f2f533",
+      "requires": {
+        "reflux-core": "^1.0.0"
       }
     },
     "regenerate": {

--- a/jsapp/package.json
+++ b/jsapp/package.json
@@ -24,7 +24,7 @@
     "react-router": "^5.2.0",
     "react-select": "^4.3.0",
     "react-tooltip": "^4.2.18",
-    "reflux": "^6.4.1",
+    "reflux-react-16": "github:ied3vil/reflux-react-16#d5f04cf7f5ea44ba26c134039127527104f2f533",
     "webpack-cli": "^4.6.0"
   },
   "devDependencies": {

--- a/jsapp/src/actions/actions.js
+++ b/jsapp/src/actions/actions.js
@@ -1,4 +1,4 @@
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import $ from 'jquery';
 import alertify from 'alertifyjs';
 

--- a/jsapp/src/components/GettingStarted.js
+++ b/jsapp/src/components/GettingStarted.js
@@ -6,7 +6,7 @@ import {Redirect} from 'react-router-dom';
 import bem from '../libs/react-create-bem-element';
 import sessionStore from '../stores/session';
 import bemRouterLink from '../libs/bemRouterLink'; // !
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import accountStore from '../stores/account';
 import authUrls from '../stores/authUrls';
 

--- a/jsapp/src/components/MetricsUiApp.js
+++ b/jsapp/src/components/MetricsUiApp.js
@@ -5,7 +5,7 @@ import reactMixin from 'react-mixin';
 import bem from '../libs/react-create-bem-element';
 import sessionStore from '../stores/session';
 import authUrls from '../stores/authUrls';
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 
 import GettingStarted from './GettingStarted';
 

--- a/jsapp/src/components/NewProject.js
+++ b/jsapp/src/components/NewProject.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import reactMixin from 'react-mixin';
 import { withRouter } from 'react-router-dom';
 import history from 'history/hash';

--- a/jsapp/src/components/ProjectList.js
+++ b/jsapp/src/components/ProjectList.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import reactMixin from 'react-mixin';
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import bem from '../libs/react-create-bem-element';
 import bemRouterLink from '../libs/bemRouterLink';
 import moment from 'moment';

--- a/jsapp/src/components/Register.js
+++ b/jsapp/src/components/Register.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import reactMixin from 'react-mixin';
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import { withRouter } from 'react-router-dom'; // to include history in the props
 import bem from '../libs/react-create-bem-element';
 import bemRouterLink from '../libs/bemRouterLink';

--- a/jsapp/src/components/Report.js
+++ b/jsapp/src/components/Report.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import reactMixin from 'react-mixin';
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import bem from '../libs/react-create-bem-element';
 import bemRouterLink from '../libs/bemRouterLink';
 import {RequireLoggedIn} from '../libs/requireLogins';

--- a/jsapp/src/libs/requireLogins.js
+++ b/jsapp/src/libs/requireLogins.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import {Redirect} from 'react-router-dom';
 import sessionStore from '../stores/session';
 

--- a/jsapp/src/stores/account.js
+++ b/jsapp/src/stores/account.js
@@ -1,4 +1,4 @@
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import actions from '../actions/actions';
 import {registration} from '../components/registrationForm';
 

--- a/jsapp/src/stores/renderings.js
+++ b/jsapp/src/stores/renderings.js
@@ -1,4 +1,4 @@
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import actions from '../actions/actions';
 import $ from 'jquery';
 import alertify from 'alertifyjs';

--- a/jsapp/src/stores/session.js
+++ b/jsapp/src/stores/session.js
@@ -1,4 +1,4 @@
-import Reflux from 'reflux';
+import Reflux from 'reflux-react-16';
 import actions from '../actions/actions';
 
 var sessionStore = Reflux.createStore({


### PR DESCRIPTION
Should avoid needing to pass `--legacy-peer-deps` to `npm`. Uses release
1.0.3, which is available on GitHub but not published to npm:
https://github.com/ied3vil/reflux-react-16/releases/tag/1.0.3

Reflux has been working successfully with React 17 in this application
since #145