### PR TITLE
Upgrade postgres to 15 and upgrade django to 4.2.15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   postgres:
-    image: postgres:11.6
+    image: postgres:15
     environment:
       - POSTGRES_USER=reports
       - POSTGRES_PASSWORD=reports

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - harfbuzz=4.3.0=hf52aaf7_1
   - icu=58.2=he6710b0_3
   - intel-openmp=2023.1.0=hdb19cb5_46306
-  - jpeg=9e=h5eee18b_2
+  - jpeg=9e=h5eee18b_3
   - kernel-headers_linux-64=3.10.0=h57e8cba_10
   - krb5=1.17.1=h173b8e3_0
   - ld_impl_linux-64=2.35.1=h7274673_9
@@ -75,7 +75,7 @@ dependencies:
   - pango=1.50.7=h05da053_0
   - pcre=8.45=h295c915_0
   - pcre2=10.42=hebb0a14_1
-  - pip=24.0=py38h06a4308_0
+  - pip=24.2=py38h06a4308_0
   - pixman=0.40.0=h7f8727e_1
   - pyasn1=0.4.8=pyhd3eb1b0_0
   - python=3.8.18=h7a1cb2a_0
@@ -137,7 +137,7 @@ dependencies:
   - r-xfun=0.6=r36h6115d3f_0
   - r-yaml=2.2.0=r36h96ca727_0
   - readline=8.2=h5eee18b_0
-  - setuptools=69.5.1=py38h06a4308_0
+  - setuptools=72.1.0=py38h06a4308_0
   - six=1.16.0=pyhd3eb1b0_1
   - sqlite=3.45.3=h5eee18b_0
   - sysroot_linux-64=2.17=h57e8cba_10
@@ -151,25 +151,25 @@ dependencies:
   - pip:
       - asgiref==3.8.1
       - backports-zoneinfo==0.2.1
-      - cffi==1.16.0
+      - cffi==1.17.0
       - charset-normalizer==3.3.2
       - cryptography==43.0.0
       - dj-database-url==2.2.0
-      - django==4.2
+      - django==4.2.15
       - django-private-storage==3.1.1
       - djangorestframework==3.15.2
       - et-xmlfile==1.1.0
-      - gunicorn==22.0.0
+      - gunicorn==23.0.0
       - huey==2.5.1
       - idna==3.7
       - importlib-metadata==8.2.0
-      - markdown==3.6
+      - markdown==3.7
       - openpyxl==3.1.5
       - psycopg2==2.9.9
       - pycparser==2.22
       - pyopenssl==24.2.1
       - requests==2.32.3
-      - sentry-sdk==2.11.0
+      - sentry-sdk==2.13.0
       - sqlparse==0.5.1
       - typing-extensions==4.12.2
       - unicodecsv==0.14.1
@@ -178,5 +178,5 @@ dependencies:
       - whitenoise==6.7.0
       - xlrd==2.0.1
       - xlwt==1.3.0
-      - zipp==3.19.2
+      - zipp==3.20.0
 prefix: /opt/conda/envs/koboreports


### PR DESCRIPTION
## Description

Update the postgres version in `docker-compose.yml` to 15 (to match production). Django 4+ needs postgres at 12 or higher.

Update django to 4.2.15 to include the [security patch](https://www.djangoproject.com/weblog/2024/aug/06/security-releases/).